### PR TITLE
Add features and plugins for overall QoL

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -50,13 +50,13 @@ Example footnote reference[^1]
 In order to get MkDocs to create anchors for all headings the following
 configuration is needed:
 
-``` md title="mkdocs.yml"
+``` yaml title="mkdocs.yml"
 markdown_extensions:
   - toc:
-      permalink: "🔗"
+      permalink: "🔗" # (1)
 ```
 
-The permalink symbol is free to choose.
+1.  The permalink symbol is free to choose.
 
 ### Link to heading from same page
 
@@ -77,7 +77,7 @@ From:
 See [SA-001](/modeling_rules/system_analysis#sa-001) for language rules.
 ```
 
-Using a relative link to the markdown file where your heading is.
+using a relative link to the markdown file where your heading is.
 
 ## Image
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -45,6 +45,40 @@ Example footnote reference[^1]
 
 [^1]: This is the footnote
 
+## References
+
+In order to get MkDocs to create anchors for all headings the following
+configuration is needed:
+
+``` md title="mkdocs.yml"
+markdown_extensions:
+  - toc:
+      permalink: "🔗"
+```
+
+The permalink symbol is free to choose.
+
+### Link to heading from same page
+
+2 sections before you can learn about using [Mermaid](#mermaid) in MkDocs
+documentation. From:
+
+``` md
+2 sections before you can learn about using [Mermaid](#mermaid) in MkDocs
+documentation.
+```
+
+### Link to heading from any other page
+
+See [SA-001](/modeling_rules/system_analysis#sa-001) for language rules.
+From:
+
+``` md
+See [SA-001](/modeling_rules/system_analysis#sa-001) for language rules.
+```
+
+Using a relative link to the markdown file where your heading is.
+
 ## Image
 
 ![Example image](example.jpg)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,14 +4,28 @@
 site_name: MBSE Handbook
 theme:
   name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.top
+    - content.code.annotate
+    - content.tooltips
+
 nav:
   - Introduction: index.md
   - Modeling Rules:
-    - System Analysis: modeling_rules/system_analysis.md
+      - System Analysis: modeling_rules/system_analysis.md
   - Demo: demo.md
 
 repo_url: https://github.com/DSD-DBS/capella-collab-manager-docs
 edit_uri: edit/main/docs
+
+plugins:
+  - search
+  - autorefs
 
 markdown_extensions:
   - meta
@@ -19,9 +33,9 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences:
       custom_fences:
-          - name: mermaid
-            class: mermaid
-            format: !!python/name:pymdownx.superfences.fence_code_format
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - abbr
   - pymdownx.snippets
   - attr_list
@@ -32,6 +46,8 @@ markdown_extensions:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
   - footnotes
+  - toc:
+      permalink: "🔗"
 
 extra:
   generator: false


### PR DESCRIPTION
This PR solves #2.

The mechanism for creating anchors on any heading is enabled and referencing sections from the same page and an other page via the heading is shown on the demo page. Also many useful [features of Material for MkDocs](https://squidfunk.github.io/mkdocs-material/reference/) were enabled that improve overall quality of life for authors as well as readers.

There are some more plugins that can be added if there is need for it. Have a look at these sources:

- [MkDocs Plugins](https://www.neoteroi.dev/mkdocs-plugins/),
- [mkdocs-jupyter](https://github.com/danielfrg/mkdocs-jupyter) and
- [Autolinks](https://github.com/midnightprioriem/mkdocs-autolinks-plugin) if relative links are too much of a hassle.